### PR TITLE
Install Substack API MCP for Cursor (pin mcp 1.x + mcp.json)

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "substack-api": {
+      "command": "${workspaceFolder}/.venv/bin/substack-api-mcp",
+      "args": [],
+      "env": {
+        "APISUBSTACK_API_KEY": "${env:APISUBSTACK_API_KEY}",
+        "SUBSTACK_PUBLICATION_URL": "${env:SUBSTACK_PUBLICATION_URL}",
+        "SUBSTACK_SID": "${env:SUBSTACK_SID}"
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ description = "MCP server to publish to Substack via any agent — Substack has 
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "mcp[cli]>=1.2.0",
+  "mcp[cli]>=1.29.0,<2",
   "requests>=2.31.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.31.0
-mcp[cli]>=1.2.0
+mcp[cli]>=1.29.0,<2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Pins `mcp[cli]` to `>=1.29.0,<2` so `pip install -e .` works (mcp 2.0 broke `mcp.server.fastmcp`).
- Adds `.cursor/mcp.json` for Cursor Desktop: runs `${workspaceFolder}/.venv/bin/substack-api-mcp` with `APISUBSTACK_API_KEY`, `SUBSTACK_PUBLICATION_URL`, `SUBSTACK_SID` from env.

## Local setup after merge
```bash
python3 -m venv .venv
source .venv/bin/activate
pip install -e .
export APISUBSTACK_API_KEY=ask_...
export SUBSTACK_PUBLICATION_URL=https://yourname.substack.com
export SUBSTACK_SID=...
```

## Cloud Agents
Project `mcp.json` is not loaded by Cloud Agents. Add this stdio server in the MCP dropdown at cursor.com/agents (or Dashboard → Integrations & MCP) with the same command/env.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faaa9-0cdb-7f05-99a4-24edf62fee1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faaa9-0cdb-7f05-99a4-24edf62fee1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

